### PR TITLE
Fix build errors with clang/libc++

### DIFF
--- a/src/helpers/OS.cpp
+++ b/src/helpers/OS.cpp
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <optional>
 
 #include <hyprutils/string/String.hpp>
 #include <hyprutils/memory/Casts.hpp>


### PR DESCRIPTION
hyprshutdown is currently the only package that
does not build with a clang/libc++ toolchain
(version 22) as std::optional and std::nullopt
are missing from libc++.

Here's the relevant output from a local ebuild `emerge -av hyprshutdown` . 

```
$ ninja -v -l0 -j24
[0/2] /usr/bin/cmake -P /var/tmp/portage/gui-apps/hyprshutdown-0.1.1/work/hyprshutdown-0.1.1_build/CMakeFiles/VerifyGlobs.cmake
[1/7] /usr/lib/llvm/22/bin/clang++-22 -DHYPRSHUTDOWN_VERSION=\"0.1.1\" -isystem /usr/include/pixman-1 -isystem /usr/include/libdrm  -O2 -pipe -march=native -fno-omit-frame-pointer -Werror=odr -Werror=strict-aliasing -std=gnu++23 -Wall -Wextra -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wpedantic -O3 -Wno-missing-braces -MD -MT CMakeFiles/hyprshutdown.dir/src/helpers/OS.cpp.o -MF CMakeFiles/hyprshutdown.dir/src/helpers/OS.cpp.o.d -o CMakeFiles/hyprshutdown.dir/src/helpers/OS.cpp.o -c /var/tmp/portage/gui-apps/hyprshutdown-0.1.1/work/hyprshutdown-0.1.1/src/helpers/OS.cpp
FAILED: [code=1] CMakeFiles/hyprshutdown.dir/src/helpers/OS.cpp.o
/usr/lib/llvm/22/bin/clang++-22 -DHYPRSHUTDOWN_VERSION=\"0.1.1\" -isystem /usr/include/pixman-1 -isystem /usr/include/libdrm  -O2 -pipe -march=native -fno-omit-frame-pointer -Werror=odr -Werror=strict-aliasing -std=gnu++23 -Wall -Wextra -Wno-unused-parameter -Wno-unused-value -Wno-missing-field-initializers -Wpedantic -O3 -Wno-missing-braces -MD -MT CMakeFiles/hyprshutdown.dir/src/helpers/OS.cpp.o -MF CMakeFiles/hyprshutdown.dir/src/helpers/OS.cpp.o.d -o CMakeFiles/hyprshutdown.dir/src/helpers/OS.cpp.o -c /var/tmp/portage/gui-apps/hyprshutdown-0.1.1/work/hyprshutdown-0.1.1/src/helpers/OS.cpp
/var/tmp/portage/gui-apps/hyprshutdown-0.1.1/work/hyprshutdown-0.1.1/src/helpers/OS.cpp:33:13: error: no template named 'optional' in namespace 'std'
   33 | static std::optional<std::string> linuxExtractFromStatus(std::ifstream& ifs, const std::string_view& what) {
      |        ~~~~~^
/var/tmp/portage/gui-apps/hyprshutdown-0.1.1/work/hyprshutdown-0.1.1/src/helpers/OS.cpp:40:16: error: no viable conversion from returned value of type 'std::string' (aka 'basic_string<char>') to function return type 'int'
   40 |         return Hyprutils::String::trim(line.substr(full.size()));
      |                ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/usr/include/c++/v1/string:1212:55: note: candidate function
 1212 |   _LIBCPP_HIDE_FROM_ABI _LIBCPP_CONSTEXPR_SINCE_CXX20 operator __self_view() const _NOEXCEPT {
      |                                                       ^
/var/tmp/portage/gui-apps/hyprshutdown-0.1.1/work/hyprshutdown-0.1.1/src/helpers/OS.cpp:43:17: error: no member named 'nullopt' in namespace 'std'
   43 |     return std::nullopt;
      |                 ^~~~~~~
3 errors generated.
```
